### PR TITLE
Fix the margin bottom in the class .features

### DIFF
--- a/static/css/hl.css
+++ b/static/css/hl.css
@@ -11,7 +11,6 @@ body {
   background:#fff;
   font-family: "Open Sans", sans-serif;
   font-size:14px;
-  margin:0 0 6em;
   padding:0;
   overflow-y:scroll;
 }
@@ -49,13 +48,26 @@ h2 {
   opacity: 0.6;
 }
 
+/*
+Element in absolute position don't have a height.
+With the property after on the body we give a real height to the footer.
+See https://css-tricks.com/snippets/css/sticky-footer/
+*/
+body:after {
+  content: "";
+  display: block;
+}
+.footer, body:after {
+  height:4em;
+}
+
 .footer {
+  position: absolute;
+  bottom: 0;
   background-color:#323232;
   color:#999;
-  position:absolute;
-  bottom:0;
   width:100%;
-  height:4em;
+
   overflow: hidden;
   line-height:2em;
 }


### PR DESCRIPTION
- remove the absolute position of the footer (so the margin-bottom of
  the .features class don't expend "in" the footer)
- remove margin-bottom of the body (so the footer stick to the bottom of
  the page)

Tested with Firefox, Chromium and Firefox mobile… 
