### PR TITLE
Redirect to Stackage page for undocumented packages

### DIFF
--- a/src/HL/Controller/Packages.hs
+++ b/src/HL/Controller/Packages.hs
@@ -9,6 +9,7 @@ module HL.Controller.Packages
     , getPackageR
     ) where
 
+import           Data.Monoid ((<>))
 import qualified Data.Vector as V
 import           HL.Controller
 import           HL.View
@@ -31,10 +32,12 @@ getPackageR name =
          case V.find ((== name) . packageName)
                      (V.concatMap commonChoices
                                   (piCommons info)) of
-           Nothing -> redirect PackagesR
+           Nothing -> onNotFound
            Just package -> handlePackage package
        Just package -> handlePackage package
   where handlePackage package =
           case packagePage package of
-            Nothing -> redirect PackagesR
+            Nothing -> onNotFound
             Just md -> lucid (packageV name md)
+
+        onNotFound = redirect $ "https://www.stackage.org/package/" <> toPathPiece name


### PR DESCRIPTION
Motivation: we can start writing docs today which refer to a stable URL
on haskell-lang.org, and fill out more docs for specific packages over
time.
