### PR TITLE
Fixed typo.

### DIFF
--- a/static/tutorial/operators.md
+++ b/static/tutorial/operators.md
@@ -40,7 +40,7 @@ One of the most common operators, and source of initial confusion, is
 the `$` operator. All this does is _apply a function_. So, `f $ x` is
 exactly equivalent to `f x`. If so, why would you ever use `$`? The
 primary reason is - for those who prefer the style - to avoid
-paratheses. For example, you can replace:
+parentheses. For example, you can replace:
 
 ```haskell
 foo (bar (baz bin))


### PR DESCRIPTION
Although "parathesis" does mean "parenthesis" as well per http://www.collinsdictionary.com/dictionary/english/parathesis , I believe "parenthesis" is much more common and easier to understand.
