### PR TITLE
Fix GitHub-specific Markdown formatting

### DIFF
--- a/static/tutorial/synonyms.md
+++ b/static/tutorial/synonyms.md
@@ -77,7 +77,7 @@ liftM :: (Monad m) => (a -> b) -> m a -> m b
 `Functor`s. Like `*>` vs `>>`, the presence of `liftM` is just a
 holdover from the days when `Functor` was not a superclass of `Monad`.
 
-## traverse_ and mapM_
+## traverse\_ and mapM\_
 
 ```haskell
 traverse_ :: (Foldable t, Applicative f) => (a -> f b) -> t a -> f ()
@@ -87,7 +87,7 @@ mapM_ :: (Foldable t, Monad m) => (a -> m b) -> t a -> m ()
 `mapM_` is `traverse_` specialized to `Monad`, relevant for the same
 superclass reason above.
 
-## sequenceA_ and sequence_
+## sequenceA\_ and sequence\_
 
 ```haskell
 sequenceA_ :: (Foldable t, Applicative f) => t (f a) -> f ()


### PR DESCRIPTION
GitHub allows special symbols (like `_`) in Markdown headers, other Markdown renderers... not so much. Not all of them, anyway.

For example, currently some of headers in the "Synonyms in base" tutorial are messed up, since `_`s in those translate to `<i>`/`</i>` pairs. This pull request simply escapes these underscores. It's GitHub-compatible.
