### PR TITLE
Standardization of commas in tuples

### DIFF
--- a/src/HL/Model.hs
+++ b/src/HL/Model.hs
@@ -9,4 +9,4 @@ import Control.Applicative
 
 -- | The model monad.
 newtype Model a = Model (IO a)
-  deriving (Monad,Functor,Applicative)
+  deriving (Monad, Functor, Applicative)

--- a/src/HL/Model/Markdown.hs
+++ b/src/HL/Model/Markdown.hs
@@ -30,7 +30,7 @@ renderMarkdown (Markdown text) =
                   }
                   (L.fromStrict text)))
   where
-    renderer lang (src,_) =
+    renderer lang (src, _) =
         if lang == Just "haskell"
             then H.preEscapedToHtml (renderText (haskellPre src))
             else H.pre $ H.toHtml src

--- a/src/HL/Types.hs
+++ b/src/HL/Types.hs
@@ -38,7 +38,7 @@ class Human a where
 data HaskellLangException
   = MarkdownFileUnavailable !FilePath
   | ReportPageNotFound !FilePath
-  deriving (Show,Typeable,Eq)
+  deriving (Show, Typeable, Eq)
 
 instance Exception HaskellLangException
 
@@ -124,7 +124,7 @@ instance ToHtml Markdown where
                           _ -> Blaze.pre rendered}
 
 newtype PackageName = PackageName Text
-  deriving (Eq,Ord,Show,FromJSON,ToJSON,ToHtml)
+  deriving (Eq, Ord, Show, FromJSON, ToJSON, ToHtml)
 
 instance Read PackageName where
   readsPrec _ str =
@@ -174,7 +174,7 @@ instance PathPiece OS where
 
 -- | Mode for rendering Haskell report.
 data Mode = Mono | Node
-  deriving (Eq,Show,Read)
+  deriving (Eq, Show, Read)
 
 instance Slug Mode where
   toSlug m =

--- a/src/HL/View.hs
+++ b/src/HL/View.hs
@@ -7,7 +7,7 @@ module HL.View
   ,module V)
   where
 
-import HL.Foundation as V (Route(..),App,Human(..),Slug(..))
+import HL.Foundation as V (Route(..), App, Human(..), Slug(..))
 import HL.Static as V
 import HL.Types as C
 

--- a/src/HL/View/Documentation.hs
+++ b/src/HL/View/Documentation.hs
@@ -47,7 +47,7 @@ inSiteDocs tutorialMap = do
            a_ [href_ "https://www.reddit.com/r/haskell_lang/comments/4udlt6/documentation_priorities/"] "discuss it on Reddit")
   where
     renderTutorial :: (TutorialKey, Tutorial) -> View App ()
-    renderTutorial (tutorialKey,Tutorial{tutorialTitle = title}) = do
+    renderTutorial (tutorialKey, Tutorial{tutorialTitle = title}) = do
         let route =
               case tutorialKey of
                 PackageTutorial pkg -> LibraryR pkg
@@ -61,11 +61,11 @@ books =
      links bookLinks
   where
     bookLinks =
-      [("Haskell Programming from first principles","http://haskellbook.com")
-      ,("Haskell: The Craft of Functional Programming","http://www.haskellcraft.com/craft3e/Home.html")
-      ,("Thinking Functionally with Haskell","http://www.cambridge.org/us/academic/subjects/computer-science/programming-languages-and-applied-logic/thinking-functionally-haskell")
-      ,("Parallel and Concurrent Programming in Haskell","http://chimera.labs.oreilly.com/books/1230000000929")
-      ,("Developing Web Applications with Haskell and Yesod","http://www.yesodweb.com/book")]
+      [("Haskell Programming from first principles", "http://haskellbook.com")
+      ,("Haskell: The Craft of Functional Programming", "http://www.haskellcraft.com/craft3e/Home.html")
+      ,("Thinking Functionally with Haskell", "http://www.cambridge.org/us/academic/subjects/computer-science/programming-languages-and-applied-logic/thinking-functionally-haskell")
+      ,("Parallel and Concurrent Programming in Haskell", "http://chimera.labs.oreilly.com/books/1230000000929")
+      ,("Developing Web Applications with Haskell and Yesod", "http://www.yesodweb.com/book")]
 
 courses :: View App ()
 courses =
@@ -74,10 +74,10 @@ courses =
      links courseLinks
   where
      courseLinks =
-       [("University of Pennsylvania's CIS 194","https://www.seas.upenn.edu/~cis194/")
-       ,("NICTA Functional Programming Course","https://github.com/NICTA/course")
-       ,("University of Virginia's CS 1501","http://shuklan.com/haskell/")
-       ,("Stanford's cs240h","http://www.scs.stanford.edu/14sp-cs240h/")]
+       [("University of Pennsylvania's CIS 194", "https://www.seas.upenn.edu/~cis194/")
+       ,("NICTA Functional Programming Course", "https://github.com/NICTA/course")
+       ,("University of Virginia's CS 1501", "http://shuklan.com/haskell/")
+       ,("Stanford's cs240h", "http://www.scs.stanford.edu/14sp-cs240h/")]
 
 tutorials :: View App ()
 tutorials =
@@ -98,26 +98,26 @@ online =
      links resources
   where
     resources =
-      [("The Haskell Wiki","http://wiki.haskell.org")
-      ,("The Haskell Wikibook","http://en.wikibooks.org/wiki/Haskell")
-      ,("FP Complete's School of Haskell","https://www.fpcomplete.com/school")
-      ,("Stephen Diehl's What I Wish I Knew When Learning Haskell","http://dev.stephendiehl.com/hask/#cabal")
-      ,("Chris Allen's List of Learning Haskell Resources","https://github.com/bitemyapp/learnhaskell")
-      ,("Bob Ippolito's Getting Started with Haskell","http://bob.ippoli.to/archives/2013/01/11/getting-started-with-haskell/")
-      ,("Albert Y.C. Lai's Haskell Notes and Examples","http://www.vex.net/~trebla/haskell/index.xhtml")
-      ,("Learning Haskell Resources on the Haskell Wiki","https://wiki.haskell.org/Learning_Haskell")]
+      [("The Haskell Wiki", "http://wiki.haskell.org")
+      ,("The Haskell Wikibook", "http://en.wikibooks.org/wiki/Haskell")
+      ,("FP Complete's School of Haskell", "https://www.fpcomplete.com/school")
+      ,("Stephen Diehl's What I Wish I Knew When Learning Haskell", "http://dev.stephendiehl.com/hask/#cabal")
+      ,("Chris Allen's List of Learning Haskell Resources", "https://github.com/bitemyapp/learnhaskell")
+      ,("Bob Ippolito's Getting Started with Haskell", "http://bob.ippoli.to/archives/2013/01/11/getting-started-with-haskell/")
+      ,("Albert Y.C. Lai's Haskell Notes and Examples", "http://www.vex.net/~trebla/haskell/index.xhtml")
+      ,("Learning Haskell Resources on the Haskell Wiki", "https://wiki.haskell.org/Learning_Haskell")]
 
 manuals :: View App ()
 manuals = do h2_ "Manuals and Guides"
              p_ "Manuals and guides that cover common Haskell tooling:"
              links tools
-  where tools = [("GHC User Guide","http://www.haskell.org/ghc/docs/latest/html/users_guide/")
-                ,("Cabal Homepage And Quick Links","https://www.haskell.org/cabal/")
-                ,("Cabal User Guide","http://www.haskell.org/cabal/users-guide/")
-                ,("Stack User Guide","https://github.com/commercialhaskell/stack/blob/master/doc/GUIDE.md")
-                ,("Haddock User Guide","http://www.haskell.org/haddock/doc/html/index.html")
-                ,("Haskeleton: A Haskell Project Skeleton","http://taylor.fausak.me/2014/03/04/haskeleton-a-haskell-project-skeleton/")
-                ,("How to Write a Haskell Program","https://wiki.haskell.org/How_to_write_a_Haskell_program")]
+  where tools = [("GHC User Guide", "http://www.haskell.org/ghc/docs/latest/html/users_guide/")
+                ,("Cabal Homepage And Quick Links", "https://www.haskell.org/cabal/")
+                ,("Cabal User Guide", "http://www.haskell.org/cabal/users-guide/")
+                ,("Stack User Guide", "https://github.com/commercialhaskell/stack/blob/master/doc/GUIDE.md")
+                ,("Haddock User Guide", "http://www.haskell.org/haddock/doc/html/index.html")
+                ,("Haskeleton: A Haskell Project Skeleton", "http://taylor.fausak.me/2014/03/04/haskeleton-a-haskell-project-skeleton/")
+                ,("How to Write a Haskell Program", "https://wiki.haskell.org/How_to_write_a_Haskell_program")]
 
 cabal :: View App ()
 cabal =
@@ -125,10 +125,10 @@ cabal =
      p_ "The Cabal guide is a good start but there's a lot to learn:"
      links cabalInfo
   where cabalInfo =
-           [("Stephen Diehl's Cabal Quickstart","http://dev.stephendiehl.com/hask/#cabal")
-           ,("An Introduction to Cabal Sandboxes","http://coldwa.st/e/blog/2013-08-20-Cabal-sandbox.html")
-           ,("The Storage and Interpretation of Cabal Packages","http://www.vex.net/~trebla/haskell/sicp.xhtml")
-           ,("The Cabal of Cabal","http://www.vex.net/~trebla/haskell/cabal-cabal.xhtml")]
+           [("Stephen Diehl's Cabal Quickstart", "http://dev.stephendiehl.com/hask/#cabal")
+           ,("An Introduction to Cabal Sandboxes", "http://coldwa.st/e/blog/2013-08-20-Cabal-sandbox.html")
+           ,("The Storage and Interpretation of Cabal Packages", "http://www.vex.net/~trebla/haskell/sicp.xhtml")
+           ,("The Cabal of Cabal", "http://www.vex.net/~trebla/haskell/cabal-cabal.xhtml")]
 
 library :: View App ()
 library =
@@ -136,12 +136,12 @@ library =
      p_ "Documentation for Haskell libraries is typically available on Hackage. We also have specialized tools for searching across it, not only by name, but by type."
      links docs
   where docs =
-         [("Hoogle API Search","http://www.haskell.org/hoogle/")
+         [("Hoogle API Search", "http://www.haskell.org/hoogle/")
          ,("FPComplete API Search", "https://www.fpcomplete.com/hoogle")
-         ,("Hayoo! API Search","http://hayoo.fh-wedel.de")
+         ,("Hayoo! API Search", "http://hayoo.fh-wedel.de")
          ,("Hackage","http://hackage.haskell.org/")
-         ,("The Typeclassopedia","https://wiki.haskell.org/Typeclassopedia")
-         ,("Haddocks for Libraries included with GHC","https://downloads.haskell.org/~ghc/latest/docs/html/libraries/index.html")]
+         ,("The Typeclassopedia", "https://wiki.haskell.org/Typeclassopedia")
+         ,("Haddocks for Libraries included with GHC", "https://downloads.haskell.org/~ghc/latest/docs/html/libraries/index.html")]
 
 report :: View App ()
 report =

--- a/src/HL/View/GetStarted.hs
+++ b/src/HL/View/GetStarted.hs
@@ -60,20 +60,20 @@ operatingSystems url mos =
                          strong_ (toHtml (toHuman os)))
      p_ [class_ "os-logos"]
         (do forM_ oses
-                  (\(os,osLogo) ->
+                  (\(os, osLogo) ->
                      a_ (concat [[class_ "os-logo"
                                  ,href_ (url (GetStartedOSR os))
                                  ,title_ (toHuman os)]
-                                ,case mos of
+                                 ,case mos of
                                    Nothing -> [class_ " os-choose "]
                                    Just os'
                                      | os' == os -> [class_ " os-selected "]
                                      | otherwise -> [class_ " os-faded "]])
                         (img_ [src_ (url (StaticR osLogo))])))
   where oses =
-          [(OSX,img_apple_logo_svg)
-          ,(Windows,img_windows_logo_svg)
-          ,(Linux,img_linux_logo_svg)]
+          [(OSX, img_apple_logo_svg)
+          ,(Windows, img_windows_logo_svg)
+          ,(Linux, img_linux_logo_svg)]
 
 -- | Show download information for the operating system.
 operatingSystemDownload :: (Route App -> Text) -> Maybe OS -> View App ()

--- a/src/HL/View/Home.hs
+++ b/src/HL/View/Home.hs
@@ -45,7 +45,7 @@ header snippetInfo url =
                       (div_ [class_ "branding"]
                             (do tag
                                 snippet)))))
-  where branding = span_ [class_ "name",background url img_logo_png] "Haskell"
+  where branding = span_ [class_ "name", background url img_logo_png] "Haskell"
         summation =
           span_ [class_ "summary"] "An advanced purely-functional programming language"
         tag = span_ [class_ "tag"] "Declarative, statically typed code."
@@ -56,23 +56,23 @@ header snippetInfo url =
                         (zip [0 ..]
                              (siSnippets snippetInfo)))
         index =
-          fst (randomR (0,(length (siSnippets snippetInfo)) - 1)
+          fst (randomR (0, (length (siSnippets snippetInfo)) - 1)
                        (mkStdGen (siSeed snippetInfo)))
 
 -- | Show a sample code.
 
 sample :: Snippet -> View App ()
 sample snippet =
-  div_ [class_ "code-sample",title_ (snippetTitle snippet)]
+  div_ [class_ "code-sample", title_ (snippetTitle snippet)]
        (haskellPre (snippetCode snippet))
 
 -- | Try Haskell section.
 try :: (Route App -> Text) -> View App ()
 try _ =
-  div_ [class_ "try",onclick_ "tryhaskell.controller.inner.click()"]
+  div_ [class_ "try", onclick_ "tryhaskell.controller.inner.click()"]
        (container_
           (row_ (do span6_ [class_ "col-md-6"] repl
-                    span6_ [class_ "col-md-6",id_ "guide"]
+                    span6_ [class_ "col-md-6", id_ "guide"]
                            (return ()))))
   where repl =
           do h2_ "Try it"
@@ -89,7 +89,7 @@ try _ =
 community :: (Route App -> Text) -> View App ()
 community url =
   div_ [id_ "community-wrapper"]
-       (do div_ [class_ "community",background url img_community_jpg]
+       (do div_ [class_ "community", background url img_community_jpg]
                 (do container_
                       [id_ "tagline"]
                       (row_ (span8_ [class_ "col-md-8"]

--- a/src/HL/View/Template.hs
+++ b/src/HL/View/Template.hs
@@ -58,13 +58,13 @@ skeleton ptitle innerhead innerbody bodyender =
     headinner =
       do title_ (toHtml ptitle)
          meta_ [charset_ "utf-8"]
-         meta_ [httpEquiv_ "X-UA-Compatible",content_ "IE edge"]
-         meta_ [name_ "viewport",content_ "width=device-width, initial-scale=1"]
-         meta_ [name_ "keywords",content_ "haskell,functional,pure,programming,lazy"]
+         meta_ [httpEquiv_ "X-UA-Compatible", content_ "IE edge"]
+         meta_ [name_ "viewport", content_ "width=device-width, initial-scale=1"]
+         meta_ [name_ "keywords", content_ "haskell,functional,pure,programming,lazy"]
          meta_ [name_ "description",
                 content_ "The Haskell purely functional programming language home page."]
          url <- lift (asks pageRender)
-         link_ [rel_ "shortcut icon",href_ (url (StaticR img_favicon_ico))]
+         link_ [rel_ "shortcut icon", href_ (url (StaticR img_favicon_ico))]
          linkcss "https://fonts.googleapis.com/css?family=Open+Sans"
          styles url
                 [StaticR css_bootstrap_min_css
@@ -116,7 +116,7 @@ styles url =
 -- | A link to CSSxs
 linkcss :: Text -> View App ()
 linkcss uri =
-  link_ [rel_ "stylesheet",type_ "text/css",href_ uri]
+  link_ [rel_ "stylesheet", type_ "text/css", href_ uri]
 
 -- | Main navigation.
 navigation :: Bool -> View App ()
@@ -140,7 +140,7 @@ navigation showBrand =
         brand =
           do url <- lift (asks pageRender)
              div_ [class_ "navbar-header"]
-                  (a_ [class_ "navbar-brand",href_ (url HomeR)]
+                  (a_ [class_ "navbar-brand", href_ (url HomeR)]
                       (do logo
                           "Haskell"))
 
@@ -157,7 +157,7 @@ bread =
      unless (length crumbs == 1)
             (ol_ [class_ "breadcrumb"]
                  (forM_ crumbs
-                        (\(route,title) ->
+                        (\(route, title) ->
                            li_ (a_ [href_ (url route)]
                                    (toHtml title)))))
 
@@ -200,13 +200,13 @@ osxWindow title content =
              (do div_ [class_ "titlebar"]
                       (do div_ [class_ "buttons"]
                                (do div_ [class_ "closebtn"]
-                                        (a_ [class_ "closebutton",href_ "#"]
+                                        (a_ [class_ "closebutton", href_ "#"]
                                             (span_ (strong_ "x")))
                                    div_ [class_ "minimize"]
-                                        (a_ [class_ "minimizebutton",href_ "#"]
+                                        (a_ [class_ "minimizebutton", href_ "#"]
                                             (span_ (strong_ (toHtmlRaw ("&ndash;" ::Text)))))
                                    div_ [class_ "zoom"]
-                                        (a_ [class_ "zoombutton",href_ "#"]
+                                        (a_ [class_ "zoombutton", href_ "#"]
                                             (span_ (strong_ "+"))))
                           (span_ [class_ "title-bar-text"] (toHtml title)))
                  div_ [class_ "content"] content))

--- a/src/Yesod/Lucid.hs
+++ b/src/Yesod/Lucid.hs
@@ -32,7 +32,7 @@ lucid :: (Y.YesodBreadcrumbs y) => HtmlT (Reader (Page y)) () -> Y.HandlerT y IO
 lucid m = do
     render <- Y.getUrlRender
     mroute <- Y.getCurrentRoute
-    (title,breadcrumbs) <- Y.breadcrumbs
+    (title, breadcrumbs) <- Y.breadcrumbs
     return
         (runReader
              (do r <- runHtmlT m
@@ -41,7 +41,7 @@ lucid m = do
                   render
                   mroute
                   (breadcrumbs ++
-                   [ (route,title)
+                   [ (route, title)
                    | Just route <- [mroute] ])))
 
 instance ToTypedContent (Html ()) where


### PR DESCRIPTION
This is no more than a fix to my OCD :smile:.
When a pattern-matching or a tuple definition happens in the same line, there will be a space after the comma. Previously, both manners were being used.

``` diff
- (x,y)
+ (x, y)
```
