### PR TITLE
Fix a link in the `vector` tutorial

### DIFF
--- a/static/tutorial/package-vector.md
+++ b/static/tutorial/package-vector.md
@@ -420,7 +420,7 @@ monad*, meaning: `IO`, strict `ST s`, and transformers sitting on top of those
 two. The type class controlling this is `PrimMonad`.
 
 You can get more information on `PrimMonad` in the [Primitive
-Haskell](primitive-haskell.md) article. Without diving into details: every
+Haskell](/tutorial/primitive-haskell) article. Without diving into details: every
 primitive monad also has an associated primitive state token type, which is
 captured with `PrimState`. As a result, the type signatures for `read` and
 `write` (for boxed vectors) look like:


### PR DESCRIPTION
If you follow the link to `/library/primitive-haskell.md` from `/library/vector` now, it says `Not Found`. I'm not at all versed in `yesod` (in particular, I'm yet to figure out how some Markdown documents in "/static/tutorial" are served from "/library", while others are served from "/tutorial"), so I'm not at all sure the fix is correct, but for me it seems like it does the right thing.