### PR TITLE
Add missing import for optparse-applicative examples

### DIFF
--- a/static/tutorial/package-optparse-applicative.md
+++ b/static/tutorial/package-optparse-applicative.md
@@ -16,6 +16,7 @@ Basic example
 Here's an example:
 
 ```haskell
+import Data.Semigroup ((<>))
 import Options.Applicative
 
 data Opts = Opts
@@ -71,6 +72,7 @@ Sub-commands example
 It's also easy to create a program with multiple sub-commands:
 
 ```haskell
+import Data.Semigroup ((<>))
 import Options.Applicative
 
 data Opts = Opts


### PR DESCRIPTION
Added an import for Data.Semigroup so that the example code compiles for optparse-applicative.