### PR TITLE
Get haskell-lang building on newer MBPs.

### DIFF
--- a/haskell-lang.cabal
+++ b/haskell-lang.cabal
@@ -65,7 +65,6 @@ library
                    , hscolour
                    , http-conduit
                    , http-types
-                   , lifted-base
                    , lucid
                    , markdown
                    , monad-extras
@@ -79,6 +78,8 @@ library
                    , containers
                    , time
                    , transformers
+                   , unliftio
+                   , unliftio-core
                    , vector
                    , wai-logger
                    , warp
@@ -185,10 +186,10 @@ test-suite haskell-lang-test
                    , safe-exceptions
                    , wai-logger
                    , fast-logger
-                   , lifted-base
                    , mtl
                    , time
                    , monad-extras
                    , network-uri
                    , spiderweb
                    , warp
+                   , unliftio

--- a/src/HL/Foundation.hs
+++ b/src/HL/Foundation.hs
@@ -12,7 +12,7 @@ module HL.Foundation
   (module HL.Static
   ,App(..)
   ,Route(..)
-  ,Handler
+  ,HL.Foundation.Handler
   ,Widget
   ,resourcesApp
   ,Slug(..)
@@ -20,10 +20,12 @@ module HL.Foundation
   ,Mode(..))
   where
 
-import Control.Concurrent.MVar.Lifted
+--import Control.Concurrent.MVar.Lifted
+--import Control.Concurrent.MVar
 import HL.Static
 import HL.Types
 
+import UnliftIO
 import qualified Data.Map as Map
 import Data.Monoid
 import Data.Text (Text)
@@ -56,10 +58,11 @@ instance Yesod App where
   -- to avoid unnecessary overhead and cookie header generation.
   makeSessionBackend _ = return Nothing
 
-instance MonadCaching (HandlerT App IO) where
+instance MonadCaching (HandlerFor App) where
   withCacheDir cont =
-    do dirVar <- fmap appCacheDir getYesod
-       withMVar dirVar cont
+    do
+      dirVar <- fmap appCacheDir getYesod
+      withMVar dirVar cont
 
 instance Human (Route App) where
   toHuman r =

--- a/src/HL/Foundation.hs
+++ b/src/HL/Foundation.hs
@@ -20,8 +20,6 @@ module HL.Foundation
   ,Mode(..))
   where
 
---import Control.Concurrent.MVar.Lifted
---import Control.Concurrent.MVar
 import HL.Static
 import HL.Types
 

--- a/src/Yesod/Caching.hs
+++ b/src/Yesod/Caching.hs
@@ -8,12 +8,12 @@ module Yesod.Caching
 
 import           Blaze.ByteString.Builder
 import           Control.Monad
-import           Control.Monad.IO.Class
+import           Control.Monad.IO.Unlift
 import           Control.Monad.Trans.Resource
 import qualified Data.ByteString.Lazy as L
 import           Data.Conduit (($$),($=),Flush(..),await,yield,ConduitM)
 import           Data.Conduit.Binary (sinkFile)
-import           Data.Conduit.Blaze
+import           Data.Conduit.ByteString.Builder
 import qualified Data.Text as T
 import           System.Directory
 import           System.FilePath
@@ -23,7 +23,7 @@ import           Yesod.Slug
 -- | Monad which contains a cache directory to which things can be
 -- read and wrote. The 'withCacheDir' may implement a mutual exclusion
 -- on this resource.
-class (MonadIO m,MonadBaseControl IO m) => MonadCaching m where
+class (MonadUnliftIO m) => MonadCaching m where
   withCacheDir :: (FilePath -> m a) -> m a
 
 -- | With the given key run the given action, caching any content

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-6.25
+resolver: lts-11.10
 
 packages:
 - .
@@ -6,9 +6,6 @@ packages:
     git: https://github.com/fpco/spiderweb
     commit: a5b7893d7473a54e3848258cef4b57ab48444f87
   extra-dep: true
-
-extra-deps:
-- safe-exceptions-0.1.4.0
 
 extra-include-dirs:
 - /usr/local/opt/icu4c/include


### PR DESCRIPTION
Hello all!

I was working on another issue, and ran into a problem -- I'm stuck on a MBP, and this ran into the library bug Apple added to macOS, which meant that this didn't build.

So (with the very patient help of @snoyberg), I got it building and running on my machine by moving the resolver to lts-11.10, and fixing some of the build gotchas that arised.