### PR TITLE
Change the Windows download options to be  friendlier to beginners

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,4 +91,4 @@ install:
 - stack --no-terminal --install-ghc $ARGS test --bench --only-dependencies
 
 script:
-- stack --no-terminal $ARGS test --bench --no-run-benchmarks --haddock --no-haddock-deps
+- stack --no-terminal $ARGS test --bench --no-run-benchmarks # Haddock is always broken --haddock --no-haddock-deps

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,6 +83,11 @@ before_install:
 install:
 - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
 - if [ -f configure.ac ]; then autoreconf -i; fi
+
+# Deal with OOM situation
+- stack --no-terminal --install-ghc $ARGS build haskell-src-exts
+- stack --no-terminal --install-ghc $ARGS build Cabal
+
 - stack --no-terminal --install-ghc $ARGS test --bench --only-dependencies
 
 script:

--- a/haskell-lang.cabal
+++ b/haskell-lang.cabal
@@ -193,3 +193,4 @@ test-suite haskell-lang-test
                    , spiderweb
                    , warp
                    , unliftio
+                   , rio

--- a/src/HL/View/GetStarted.hs
+++ b/src/HL/View/GetStarted.hs
@@ -100,14 +100,14 @@ operatingSystemDownload url mos =
 windowsDownload :: (Route App -> Text) -> View App ()
 windowsDownload _ =
       do p_ (do "Download and run the installer: ")
-         (a_ [ class_ "windows-button"
+         (a_ [ class_ "btn btn-primary"
              , href_ "https://www.stackage.org/stack/windows-x86_64-installer"
              ]
-                         "Windows")
+                         "Windows 64-bit installer")
          div_ [class_ "muted-choices"]
            (do
-             p_ (do "For those on older machines, or running a legacy OS, we also offer a 32-bit version: ")
-             (a_ [href_ "https://www.stackage.org/stack/windows-i386-installer"]
+             p_ (do "For those on older machines, or running a legacy OS, we also offer a 32-bit version: "
+                    a_ [href_ "https://www.stackage.org/stack/windows-i386-installer"]
                          "Windows 32-bit"))
 
 -- | Linux download details.

--- a/src/HL/View/GetStarted.hs
+++ b/src/HL/View/GetStarted.hs
@@ -94,10 +94,20 @@ operatingSystemDownload url mos =
     Just Linux ->
       linuxDownload url
     Just Windows ->
+      windowsDownload url
+
+
+windowsDownload :: (Route App -> Text) -> View App ()
+windowsDownload _ =
       do p_ (do "Download and run the installer: ")
-         ul_ (do li_ (a_ [href_ "https://www.stackage.org/stack/windows-x86_64-installer"]
-                         "Windows 64-bit")
-                 li_ (a_ [href_ "https://www.stackage.org/stack/windows-i386-installer"]
+         (a_ [ class_ "windows-button"
+             , href_ "https://www.stackage.org/stack/windows-x86_64-installer"
+             ]
+                         "Windows")
+         div_ [class_ "muted-choices"]
+           (do
+             p_ (do "For those on older machines, or running a legacy OS, we also offer a 32-bit version: ")
+             (a_ [href_ "https://www.stackage.org/stack/windows-i386-installer"]
                          "Windows 32-bit"))
 
 -- | Linux download details.

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,11 +1,7 @@
-resolver: lts-11.10
+resolver: nightly-2018-06-20
 
-packages:
-- .
-- location:
-    git: https://github.com/fpco/spiderweb
-    commit: a5b7893d7473a54e3848258cef4b57ab48444f87
-  extra-dep: true
+extra-deps:
+- archive: https://github.com/fpco/spiderweb/archive/7acb788f62e7c46b9d72f29331561a3d20821496.tar.gz
 
 extra-include-dirs:
 - /usr/local/opt/icu4c/include

--- a/static/css/hl.css
+++ b/static/css/hl.css
@@ -99,6 +99,17 @@ h2 {
              text-decoration: none;
            }
 
+
+a.windows-button {
+    text-decoration: none;
+    background-color: #EEEEEE;
+    color: #333333;
+    padding: 2px 6px 2px 6px;
+    border-top: 1px solid #CCCCCC;
+    border-right: 1px solid #333333;
+    border-bottom: 1px solid #333333;
+    border-left: 1px solid #CCCCCC;
+}
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
    Syntax highlighting for general code blocks
 */

--- a/static/tutorial/package-binary.md
+++ b/static/tutorial/package-binary.md
@@ -1,4 +1,3 @@
-
 # Serializing data---the binary library
 
 *binary* is straightforward to use library for decoding (parsing)
@@ -6,11 +5,11 @@ and encoding binary data. There are a number of ways to work with
 binary, ways that range from simple to complex.
 
 
-## Decoding and encoding standard data types. 
+## Decoding and encoding standard data types.
 
 Byte strings can be trivially decoded to Haskell values, provided that the types of those values are instances of `Binary`. Analogously, types that are instances of `Binary` can easily be encoded back to byte strings. *binary* comes with convenient `Binary` instances for a good number of the standard data types including numbers, booleans, lists, tuples, and so on.
 
-Let us try these instances out in GHCi. You'll need to import 
+Let us try these instances out in GHCi. You'll need to import
 `Data.Binary` to run the examples below.
 
 ```
@@ -56,26 +55,26 @@ import Data.Binary
 import Data.Text
 import GHC.Generics (Generic)
 
-data Transaction = 
-  Txn { account :: Text, amount :: Float } 
+data Transaction =
+  Txn { account :: Text, amount :: Float }
   deriving (Generic, Show)
 
 instance Binary Transaction
 
 main :: IO ()
 main = do
-  let bytes = 
+  let bytes =
    encode (Txn { account = "Cash", amount = 10 })
   putStrLn $ "Encode: " ++ show bytes
-  putStrLn $ "Decode: " ++ 
+  putStrLn $ "Decode: " ++
     show (decode bytes :: Transaction)
 ```
 
-## Custom decoding and encoding 
+## Custom decoding and encoding
 
 `Binary` instances may also be written by hand.
 
-For decoding, you need to define `get`, of type `Get t` where `Get` is an instance of `Monad`.  
+For decoding, you need to define `get`, of type `Get t` where `Get` is an instance of `Monad`.
 
 For encoding, you need to provide a definition for `put`, which is a function that takes a value of the type you wish to encode and a value of type `Put`. By definition, `Put = PutM ()`
 where `PutM` is also an instance of `Monad`.
@@ -104,13 +103,14 @@ instance Binary Transaction where
 
 main :: IO () -- The main action is unchanged from before.
 main = do
-  let bytes = 
+  let bytes =
     encode (Txn { account = "Cash", amount = 1000 })
   putStrLn $ "Encode: " ++ show bytes
-  putStrLn $ "Decode: " ++ 
+  putStrLn $ "Decode: " ++
     show (decode bytes :: Transaction)
 ```
 
 
 ## Conclusion
+
 While quite straightforward to use, the *binary* library is vulnerable to two criticisms. Firstly, as its creator Duncan Coutts pointed out, `binary` entangles the issue of serializing Haskell values with that of read/writing externally defined formats. This can be confusing. Secondly, the error messages one may encounter when using `binary`are perhaps not as helpful as one would like. The `cereal` library offers to address the latter (though not the former) problem.

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -10,6 +10,7 @@ import SpiderWeb
 import Data.String (fromString)
 import Network.Wai.Handler.Warp (testWithApplication)
 import Yesod.Core (toWaiApp)
+import RIO (runSimpleApp)
 
 main :: IO ()
 main = hspec $ do
@@ -19,4 +20,4 @@ main = hspec $ do
 
     it "link checking" $
       testWithApplication (mkApp >>= toWaiApp) $ \port ->
-        void $ download $ fromString $ "http://localhost:" ++ show port
+        void $ runSimpleApp $ download $ fromString $ "http://localhost:" ++ show port


### PR DESCRIPTION
This is in reference to https://github.com/snoyberg/haskell-hackathon/issues/8

In short, the Get Started page doesn't offer any way to decide between the Windows 32 or 64 bit download options. Since 64 bit is the one people are going to want in the overwhelming majority of cases, prioritize that option.