### PR TITLE
Adds Ingress and makes review apps manual

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,6 +29,7 @@ variables:
   - &KUBEAPPLY
     kubectl apply -f <(envsubst <etc/kube/service_template.yaml) &&
     kubectl apply -f <(envsubst <etc/kube/deployment_template.yaml) &&
+    kubectl apply -f <(envsubst <etc/kube/ingress_template.yaml) &&
     kubectl rollout status -f <(envsubst <etc/kube/deployment_template.yaml)
 
 build:
@@ -47,16 +48,18 @@ build:
 
 deploy_review:
   stage: deploy
+  when: manual
   only:
     - branches
   except:
     - master
   environment:
     name: haskell-lang-review/$CI_BUILD_REF_NAME
-    url: https://haskell-lang-$CI_BUILD_REF_SLUG.fpco-untrusted.fpcomplete.com/
+    url: https://haskell-lang-$CI_BUILD_REF_SLUG.fpco-public.fpcomplete.com/
     on_stop: stop_review
   variables:
-    APPROOT: https://haskell-lang-$CI_BUILD_REF_SLUG.fpco-untrusted.fpcomplete.com/
+    APPROOT: https://haskell-lang-$CI_BUILD_REF_SLUG.fpco-public.fpcomplete.com/
+    HOST: haskell-lang-$CI_BUILD_REF_SLUG.fpco-public.fpcomplete.com
   script:
     - *KUBELOGIN
     - *KUBEAPPLY
@@ -73,7 +76,7 @@ stop_review:
     action: stop
   script:
     - *KUBELOGIN
-    - kubectl delete service,deployment -l app=${CI_ENVIRONMENT_SLUG}
+    - kubectl delete service,deployment,ingress,secret -l app=${CI_ENVIRONMENT_SLUG}
 
 deploy_prod:
   stage: deploy

--- a/etc/kube/ingress_template.yaml
+++ b/etc/kube/ingress_template.yaml
@@ -1,0 +1,21 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: "${DEPLOYMENT_NAME}"
+  labels:
+    app: "${DEPLOYMENT_APP}"
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    kubernetes.io/tls-acme: "true"
+spec:
+  rules:
+    - host: "${HOST}"
+      http:
+        paths:
+          - backend:
+              serviceName: "${DEPLOYMENT_NAME}"
+              servicePort: 9090
+  tls:
+    - hosts:
+      - "${HOST}"
+      secretName: "${DEPLOYMENT_NAME}-tls"


### PR DESCRIPTION
This PR adds an Ingress controller to the kube templates and uses that in combo with external-dns+kube-lego (deployed on the CI cluster) to automatically generate a SSL cert and add a Route53 entry to a newly deployed gitlab review apps. The app will get deployed in the fpco-public namespace and will be available on the following URL: `haskell-lang-$CI_BUILD_REF_SLUG.fpco-public.fpcomplete.com` which should be visible from the Gitlab CI/CD interface. I've also switched review app deploys to manual so they need to be triggered in the Gitlab interface.

ping @snoyberg @borsboom 