### PR TITLE
WIP: Move kube to helm

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: registry.gitlab.fpcomplete.com/fpco/default-build-image:1954
+image: registry.gitlab.fpcomplete.com/fpco/default-build-image:5354
 
 cache:
   key: "$CI_BUILD_NAME"
@@ -31,6 +31,11 @@ variables:
     kubectl apply -f <(envsubst <etc/kube/deployment_template.yaml) &&
     kubectl apply -f <(envsubst <etc/kube/ingress_template.yaml) &&
     kubectl rollout status -f <(envsubst <etc/kube/deployment_template.yaml)
+  - &HELMUPGRADE
+    helm upgrade -i "${DEPLOYMENT_NAME}" etc/helm --set name="${DEPLOYMENT_NAME}" --set app="${DEPLOYMENT_APP}" --set image.image="${DEPLOYMENT_IMAGE}" --set image.env.approot="{$APPROOT} --set ingress.hosts="${HOST}" --values values/$CI_ENVIRONMENT_NAME.yaml
+  - &HELMCHECK
+    helm ls &&
+    helm status "${DEPLOYMENT_NAME}"
 
 build:
   stage: build
@@ -62,7 +67,8 @@ deploy_review:
     HOST: haskell-lang-$CI_BUILD_REF_SLUG.fpco-public.fpcomplete.com
   script:
     - *KUBELOGIN
-    - *KUBEAPPLY
+    - *HELMUPGRADE
+    - *HELMCHECK
 
 stop_review:
   stage: deploy
@@ -76,7 +82,8 @@ stop_review:
     action: stop
   script:
     - *KUBELOGIN
-    - kubectl delete service,deployment,ingress,secret -l app=${CI_ENVIRONMENT_SLUG}
+    - helm delete --purge "${DEPLOYMENT_IMAGE}"
+    - helm ls
 
 deploy_prod:
   stage: deploy

--- a/etc/helm/.helmignore
+++ b/etc/helm/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/etc/helm/Chart.yaml
+++ b/etc/helm/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: Haskell-lang helm chart for Kubernetes
+name: haskell-lang
+version: v0.1.0

--- a/etc/helm/templates/NOTES.txt
+++ b/etc/helm/templates/NOTES.txt
@@ -1,0 +1,19 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.ingress.path }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "haskell-lang.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "haskell-lang.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "haskell-lang.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "haskell-lang.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:80
+{{- end }}

--- a/etc/helm/templates/_helpers.tpl
+++ b/etc/helm/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "haskell-lang.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "haskell-lang.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "haskell-lang.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/etc/helm/templates/deployment.yaml
+++ b/etc/helm/templates/deployment.yaml
@@ -1,0 +1,60 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ .Values.deployment.name }}
+spec:
+  replicas: {{ .Values.image.replicas }}
+  minReadySeconds: {{ .Values.image.minReadySeconds }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.deployment.app }}
+    spec:
+      containers:
+        - name: haskell-lang
+          image: {{ .Values.image.image }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: PORT
+              value: {{ .Values.image.port.containerPort | quote }}
+            - name: APPROOT
+              value: {{ .Values.image.env.approot | quote}}
+          workingDir: /haskell-lang
+          command:
+            - haskell-lang
+          ports:
+            - name: http
+              containerPort: {{ .Values.image.port.containerPort }}
+          readinessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.image.port.containerPort }}
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
+            periodSeconds: 5
+            successThreshold: 1
+          livenessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.image.port.containerPort }}
+            initialDelaySeconds: 60
+            timeoutSeconds: 1
+            periodSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+      imagePullSecrets:
+        - name: registry-key

--- a/etc/helm/templates/deployment.yaml
+++ b/etc/helm/templates/deployment.yaml
@@ -1,14 +1,14 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: {{ .Values.deployment.name }}
+  name: {{ .Values.name }}
 spec:
   replicas: {{ .Values.image.replicas }}
   minReadySeconds: {{ .Values.image.minReadySeconds }}
   template:
     metadata:
       labels:
-        app: {{ .Values.deployment.app }}
+        app: {{ .Values.app }}
     spec:
       containers:
         - name: haskell-lang

--- a/etc/helm/templates/ingress.yaml
+++ b/etc/helm/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-{{- $fullName := .Values.deployment.name -}}
+{{- $fullName := .Values.name -}}
 {{- $ingressPath := .Values.ingress.path -}}
 {{- $ingressServicePort := .Values.ingress.servicePort -}}
 apiVersion: extensions/v1beta1
@@ -7,7 +7,7 @@ kind: Ingress
 metadata:
   name: {{ $fullName }}
   labels:
-    app: {{ .Values.deployment.app }}
+    app: {{ .Values.app }}
     chart: {{ template "haskell-lang.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}

--- a/etc/helm/templates/ingress.yaml
+++ b/etc/helm/templates/ingress.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := .Values.deployment.name -}}
+{{- $ingressPath := .Values.ingress.path -}}
+{{- $ingressServicePort := .Values.ingress.servicePort -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app: {{ .Values.deployment.app }}
+    chart: {{ template "haskell-lang.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  tls:
+    - hosts:
+      {{- range .Values.ingress.hosts }}
+        - {{ . }}
+      {{- end }}
+      secretName: {{ $fullName }}-tls
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: 9090
+  {{- end }}
+{{- end }}
+

--- a/etc/helm/templates/service.yaml
+++ b/etc/helm/templates/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.deployment.name }}
+  labels:
+    app: {{ .Values.deployment.app }}
+    chart: {{ template "haskell-lang.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      name: http
+  selector:
+    app: {{ .Values.deployment.app }}

--- a/etc/helm/templates/service.yaml
+++ b/etc/helm/templates/service.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.deployment.name }}
+  name: {{ .Values.name }}
   labels:
-    app: {{ .Values.deployment.app }}
+    app: {{ .Values.app }}
     chart: {{ template "haskell-lang.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -14,4 +14,4 @@ spec:
       targetPort: http
       name: http
   selector:
-    app: {{ .Values.deployment.app }}
+    app: {{ .Values.app }}

--- a/etc/helm/values.yaml
+++ b/etc/helm/values.yaml
@@ -1,17 +1,4 @@
-# Default values for haskell-lang.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
-# set deployment.name=$DEPLOYMENT_APP
-# set deployment.name="${DEPLOYMENT_APP}"
-# set image.image=DEPLOYMENT_IMAGE
-# set image.env.approot=$APPROOT
-
-deployment:
-  name: "${DEPLOYMENT_NAME}"
-  app:  "${DEPLOYMENT_APP}"
-
 image:
-  image: "${DEPLOYMENT_IMAGE}"
   pullPolicy: IfNotPresent
   replicas: 2
   minReadySeconds: 5

--- a/etc/helm/values.yaml
+++ b/etc/helm/values.yaml
@@ -1,0 +1,47 @@
+# Default values for haskell-lang.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+# set deployment.name=$DEPLOYMENT_APP
+# set deployment.name="${DEPLOYMENT_APP}"
+# set image.image=DEPLOYMENT_IMAGE
+# set image.env.approot=$APPROOT
+
+deployment:
+  name: "${DEPLOYMENT_NAME}"
+  app:  "${DEPLOYMENT_APP}"
+
+image:
+  image: "${DEPLOYMENT_IMAGE}"
+  pullPolicy: IfNotPresent
+  replicas: 2
+  minReadySeconds: 5
+  env:
+    approot: "${APPROOT}"
+  port:
+    containerPort: 9090
+
+service:
+  type: ClusterIP
+  port: "9090"
+
+ingress:
+  enabled: true
+  annotations:
+     kubernetes.io/ingress.class: "nginx"
+     kubernetes.io/tls-acme: "true"
+  path: /
+  hosts:
+    - "${HOST}"
+
+resources: {}
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/etc/helm/values/production.yaml
+++ b/etc/helm/values/production.yaml
@@ -1,0 +1,36 @@
+name: "haskell-lang-prod"
+app:  "haskell-lang-prod"
+
+image:
+  image: "fpco/haskell-lang-prod:latest"
+  pullPolicy: Always
+  replicas: 2
+  minReadySeconds: 5
+  env:
+    approot: "https://haskell-lang.org"
+  port:
+    containerPort: 9090
+
+service:
+  type: ClusterIP
+  port: "9090"
+
+ingress:
+  enabled: true
+  annotations:
+     kubernetes.io/ingress.class: "nginx"
+     kubernetes.io/tls-acme: "true"
+  path: /
+
+resources: {}
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/etc/helm/values/staging.yaml
+++ b/etc/helm/values/staging.yaml
@@ -2,8 +2,6 @@ image:
   pullPolicy: IfNotPresent
   replicas: 2
   minReadySeconds: 5
-  env:
-    approot: "${APPROOT}"
   port:
     containerPort: 9090
 
@@ -17,8 +15,6 @@ ingress:
      kubernetes.io/ingress.class: "nginx"
      kubernetes.io/tls-acme: "true"
   path: /
-  hosts:
-    - "${HOST}"
 
 resources: {}
   #  cpu: 100m


### PR DESCRIPTION
This PR migrate the kube config to helm charts:
- Migrate the deployment template, ingress and service
- The most used values were moved to values.yaml
 
TODO
- [x] Update Review apps
- [x] Remove the DNS entries manually
- [ ] Make a list of dependecies before deploy to prod
- [ ] Deploy prod

This is PR continue the deployment of the helm chart described in the PR https://github.com/haskell-lang/haskell-lang/pull/150